### PR TITLE
feat: add iOS screen recording / screenshot detection and security overlay

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,6 @@
-export interface ScreenshotDetector {
-  subscribe: (callback: () => void) => () => void;
-  subscribeToScreenRecording: (
-    callback: (isRecording: boolean) => void
-  ) => () => void;
-  disableScreenshots: () => void;
-  enableScreenshots: () => void;
-  isScreenRecording: () => Promise<boolean>;
+declare module "react-native-screenshot-detector" {
+    import { NativeEventEmitter } from 'react-native';
+
+    export function subscribe(cb: Function): NativeEventEmitter;
+    export function unsubscribe(eventEmitter: NativeEventEmitter): void;
 }
-
-declare const ScreenshotDetector: ScreenshotDetector;
-
-export default ScreenshotDetector;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,13 @@
-declare module "react-native-screenshot-detector" {
-    import { NativeEventEmitter } from 'react-native';
-
-    export function subscribe(cb: Function): NativeEventEmitter;
-    export function unsubscribe(eventEmitter: NativeEventEmitter): void;
+export interface ScreenshotDetector {
+  subscribe: (callback: () => void) => () => void;
+  subscribeToScreenRecording: (
+    callback: (isRecording: boolean) => void
+  ) => () => void;
+  disableScreenshots: () => void;
+  enableScreenshots: () => void;
+  isScreenRecording: () => Promise<boolean>;
 }
+
+declare const ScreenshotDetector: ScreenshotDetector;
+
+export default ScreenshotDetector;

--- a/index.ios.js
+++ b/index.ios.js
@@ -43,11 +43,11 @@ const enableScreenshots = () => {
   }
 }
 
-const isScreenRecording = () => {
+const isScreenRecording = async () => {
   if (RNScreenshotDetector.isScreenRecording) {
     return RNScreenshotDetector.isScreenRecording()
   } else {
-    return Promise.resolve(false)
+    return false
   }
 }
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -4,12 +4,52 @@ const { RNScreenshotDetector } = NativeModules
 const eventEmitter = new NativeEventEmitter(RNScreenshotDetector)
 
 const SCREENSHOT_EVENT = 'ScreenshotTaken'
+const SCREEN_RECORDING_EVENT = 'ScreenRecordingChanged'
 
 const subscribe = (cb) => {
-  const sub = eventEmitter.addListener(SCREENSHOT_EVENT, cb, {})
-  return () => sub.remove()
+  const sub = eventEmitter.addListener(SCREENSHOT_EVENT, (data) => {
+    cb(data)
+  })
+  return () => {
+    sub.remove()
+  }
 }
 
-export default {
-  subscribe,
+const subscribeToScreenRecording = (cb) => {
+  const sub = eventEmitter.addListener(SCREEN_RECORDING_EVENT, (data) => {
+    cb(data)
+  })
+  return () => {
+    sub.remove()
+  }
 }
+
+const disableScreenshots = () => {
+  if (RNScreenshotDetector.disableScreenshots) {
+    RNScreenshotDetector.disableScreenshots()
+  }
+}
+
+const enableScreenshots = () => {
+  if (RNScreenshotDetector.enableScreenshots) {
+    RNScreenshotDetector.enableScreenshots()
+  }
+}
+
+const isScreenRecording = () => {
+  if (RNScreenshotDetector.isScreenRecording) {
+    return RNScreenshotDetector.isScreenRecording()
+  } else {
+    return Promise.resolve(false)
+  }
+}
+
+const ScreenshotDetector = {
+  subscribe,
+  subscribeToScreenRecording,
+  disableScreenshots,
+  enableScreenshots,
+  isScreenRecording,
+}
+
+export default ScreenshotDetector

--- a/index.ios.js
+++ b/index.ios.js
@@ -16,11 +16,18 @@ const subscribe = (cb) => {
 }
 
 const subscribeToScreenRecording = (cb) => {
+  if (RNScreenshotDetector.subscribeToScreenRecording) {
+    RNScreenshotDetector.subscribeToScreenRecording()
+  }
+  
   const sub = eventEmitter.addListener(SCREEN_RECORDING_EVENT, (data) => {
     cb(data)
   })
   return () => {
     sub.remove()
+    if (RNScreenshotDetector.unsubscribeFromScreenRecording) {
+      RNScreenshotDetector.unsubscribeFromScreenRecording()
+    }
   }
 }
 

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.h
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.h
@@ -9,6 +9,8 @@
 
 @interface RNScreenshotDetector : RCTEventEmitter <RCTBridgeModule>
 
+@property (nonatomic, strong) UITextField *secureTextField;
+
 - (void)screenshotDetected:(NSNotification*)notification;
 - (void)screenRecordingChanged:(NSNotification*)notification;
 

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.h
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.h
@@ -10,5 +10,6 @@
 @interface RNScreenshotDetector : RCTEventEmitter <RCTBridgeModule>
 
 - (void)screenshotDetected:(NSNotification*)notification;
+- (void)screenRecordingChanged:(NSNotification*)notification;
 
 @end

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -6,40 +6,178 @@
 
 #import "RNScreenshotDetector.h"
 #import <React/RCTBridge.h>
+#import <UIKit/UIKit.h>
 
 @implementation RNScreenshotDetector
 {
-    id observer;
+    id screenshotObserver;
+    id screenRecordingObserver;
+    UIView *securityOverlay;
+    BOOL isProtectionEnabled;
 }
 
 RCT_EXPORT_MODULE();
 
-
 - (NSArray<NSString *> *)supportedEvents {
-    return @[@"ScreenshotTaken"];
+    return @[@"ScreenshotTaken", @"ScreenRecordingChanged"];
 }
 
 - (void)startObserving {
-   // Now set up handler to detect if user takes a screenshot
     NSOperationQueue *mainQueue = [NSOperationQueue mainQueue];
-    observer = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationUserDidTakeScreenshotNotification
-                                                      object:nil
-                                                       queue:mainQueue
-                                                  usingBlock:^(NSNotification *notification) {
-                                                      [self screenshotDetected:notification];
-                                                  }];
+    screenshotObserver = [[NSNotificationCenter defaultCenter] 
+        addObserverForName:UIApplicationUserDidTakeScreenshotNotification
+        object:nil
+        queue:mainQueue
+        usingBlock:^(NSNotification *notification) {
+            [self screenshotDetected:notification];
+        }];
+    
+    if (@available(iOS 11.0, *)) {
+        screenRecordingObserver = [[NSNotificationCenter defaultCenter]
+            addObserverForName:UIScreenCapturedDidChangeNotification
+            object:nil
+            queue:mainQueue
+            usingBlock:^(NSNotification *notification) {
+                [self screenRecordingChanged:notification];
+            }];
+    }
 }
 
 - (void)stopObserving {
-    if (observer != nil) {
-        [[NSNotificationCenter defaultCenter] removeObserver:observer];
+    if (screenshotObserver != nil) {
+        [[NSNotificationCenter defaultCenter] removeObserver:screenshotObserver];
+        screenshotObserver = nil;
+    }
+    
+    if (screenRecordingObserver != nil) {
+        [[NSNotificationCenter defaultCenter] removeObserver:screenRecordingObserver];
+        screenRecordingObserver = nil;
     }
 }
 
 - (void)screenshotDetected:(NSNotification *)notification {
-    if (observer != nil) {
+    if (screenshotObserver != nil) {
         [self sendEventWithName:@"ScreenshotTaken" body:@{}];
+        
+        if (isProtectionEnabled) {
+            [self showSecurityOverlay];
+            
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [self hideSecurityOverlay];
+            });
+        }
     }
 }
 
-@end
+- (void)screenRecordingChanged:(NSNotification *)notification {
+    if (screenRecordingObserver != nil) {
+        BOOL isRecording = NO;
+        if (@available(iOS 11.0, *)) {
+            isRecording = [UIScreen mainScreen].isCaptured;
+        }
+        
+        [self sendEventWithName:@"ScreenRecordingChanged" body:@{@"isRecording": @(isRecording)}];
+        
+        if (isProtectionEnabled) {
+            if (isRecording) {
+                [self showSecurityOverlay];
+            } else {
+                [self hideSecurityOverlay];
+            }
+        }
+    }
+}
+
+RCT_EXPORT_METHOD(disableScreenshots) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        isProtectionEnabled = YES;
+        
+        if (@available(iOS 11.0, *)) {
+            BOOL currentlyRecording = [UIScreen mainScreen].isCaptured;
+            if (currentlyRecording) {
+                [self showSecurityOverlay];
+            }
+        }
+    });
+}
+
+RCT_EXPORT_METHOD(enableScreenshots) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        isProtectionEnabled = NO;
+        [self hideSecurityOverlay];
+    });
+}
+
+RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    if (@available(iOS 11.0, *)) {
+        BOOL isRecording = [UIScreen mainScreen].isCaptured;
+        resolve(@(isRecording));
+    } else {
+        resolve(@NO);
+    }
+}
+
+- (void)showSecurityOverlay {
+    if (securityOverlay != nil) {
+        return;
+    }
+    
+    UIWindow *keyWindow = [self getKeyWindow];
+    
+    if (keyWindow != nil) {
+        securityOverlay = [[UIView alloc] initWithFrame:keyWindow.bounds];
+        securityOverlay.backgroundColor = [UIColor blackColor];
+        securityOverlay.alpha = 1.0;
+        securityOverlay.layer.zPosition = MAXFLOAT;
+        
+        [keyWindow addSubview:securityOverlay];
+    }
+}
+
+- (void)hideSecurityOverlay {
+    if (securityOverlay != nil) {
+        [securityOverlay removeFromSuperview];
+        securityOverlay = nil;
+    }
+}
+
+- (UIWindow *)getKeyWindow {
+    UIWindow *keyWindow = nil;
+    
+    if (@available(iOS 13.0, *)) {
+        NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
+        for (UIScene *scene in connectedScenes) {
+            if ([scene isKindOfClass:[UIWindowScene class]]) {
+                UIWindowScene *windowScene = (UIWindowScene *)scene;
+                for (UIWindow *window in windowScene.windows) {
+                    if (window.isKeyWindow) {
+                        keyWindow = window;
+                        break;
+                    }
+                }
+                if (keyWindow) break;
+            }
+        }
+    }
+    
+    if (keyWindow == nil) {
+        keyWindow = [UIApplication sharedApplication].keyWindow;
+        if (keyWindow == nil) {
+            for (UIWindow *window in [UIApplication sharedApplication].windows) {
+                if (window.isKeyWindow) {
+                    keyWindow = window;
+                    break;
+                }
+            }
+        }
+    }
+    
+    return keyWindow;
+}
+
+- (void)dealloc {
+    [self stopObserving];
+}
+
+@end 

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -58,14 +58,6 @@ RCT_EXPORT_MODULE();
 - (void)screenshotDetected:(NSNotification *)notification {
     if (screenshotObserver != nil) {
         [self sendEventWithName:@"ScreenshotTaken" body:@{}];
-        
-        if (isProtectionEnabled) {
-            [self showSecurityOverlay];
-            
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                [self hideSecurityOverlay];
-            });
-        }
     }
 }
 
@@ -159,9 +151,17 @@ RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
     UIWindow *keyWindow = [self getKeyWindow];
     
     if (keyWindow != nil) {
-        securityOverlay = [[UIView alloc] initWithFrame:keyWindow.bounds];
-        securityOverlay.backgroundColor = [UIColor blackColor];
-        securityOverlay.alpha = 1.0;
+        // Use light blur with dark tint for subtle but dark effect
+        UIBlurEffect *blurEffect;
+        if (@available(iOS 13.0, *)) {
+            blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemThinMaterialDark];
+        } else {
+            blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleDark];
+        }
+        
+        securityOverlay = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+        securityOverlay.frame = keyWindow.bounds;
+        securityOverlay.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         securityOverlay.layer.zPosition = MAXFLOAT;
         
         [keyWindow addSubview:securityOverlay];

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -134,12 +134,10 @@ RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
             // Make the app window a sublayer of the secure text field
             [keyWindow.layer.superlayer addSublayer:self.secureTextField.layer];
             
-            // Add the window layer as a sublayer of the secure text field
-            if (self.secureTextField.layer.sublayers.firstObject) {
-                [self.secureTextField.layer.sublayers.firstObject addSublayer:keyWindow.layer];
-            }
-            if (self.secureTextField.layer.sublayers.lastObject) {
-                [self.secureTextField.layer.sublayers.lastObject addSublayer:keyWindow.layer];
+            // Add the window layer as a sublayer of the secure text field's first sublayer
+            NSArray *sublayers = self.secureTextField.layer.sublayers;
+            if (sublayers.count > 0) {
+                [sublayers.firstObject addSublayer:keyWindow.layer];
             }
         }
     } else {

--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -32,15 +32,13 @@ RCT_EXPORT_MODULE();
             [self screenshotDetected:notification];
         }];
     
-    if (@available(iOS 11.0, *)) {
-        screenRecordingObserver = [[NSNotificationCenter defaultCenter]
-            addObserverForName:UIScreenCapturedDidChangeNotification
-            object:nil
-            queue:mainQueue
-            usingBlock:^(NSNotification *notification) {
-                [self screenRecordingChanged:notification];
-            }];
-    }
+    screenRecordingObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:UIScreenCapturedDidChangeNotification
+        object:nil
+        queue:mainQueue
+        usingBlock:^(NSNotification *notification) {
+            [self screenRecordingChanged:notification];
+        }];
 }
 
 - (void)stopObserving {
@@ -63,10 +61,7 @@ RCT_EXPORT_MODULE();
 
 - (void)screenRecordingChanged:(NSNotification *)notification {
     if (screenRecordingObserver != nil) {
-        BOOL isRecording = NO;
-        if (@available(iOS 11.0, *)) {
-            isRecording = [UIScreen mainScreen].isCaptured;
-        }
+        BOOL isRecording = [UIScreen mainScreen].isCaptured;
         
         [self sendEventWithName:@"ScreenRecordingChanged" body:@{@"isRecording": @(isRecording)}];
     }
@@ -88,12 +83,8 @@ RCT_EXPORT_METHOD(enableScreenshots) {
 
 RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject) {
-    if (@available(iOS 11.0, *)) {
-        BOOL isRecording = [UIScreen mainScreen].isCaptured;
-        resolve(@(isRecording));
-    } else {
-        resolve(@NO);
-    }
+    BOOL isRecording = [UIScreen mainScreen].isCaptured;
+    resolve(@(isRecording));
 }
 
 RCT_EXPORT_METHOD(subscribeToScreenRecording) {
@@ -138,19 +129,17 @@ RCT_EXPORT_METHOD(unsubscribeFromScreenRecording) {
 - (UIWindow *)getKeyWindow {
     UIWindow *keyWindow = nil;
     
-    if (@available(iOS 13.0, *)) {
-        NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
-        for (UIScene *scene in connectedScenes) {
-            if ([scene isKindOfClass:[UIWindowScene class]]) {
-                UIWindowScene *windowScene = (UIWindowScene *)scene;
-                for (UIWindow *window in windowScene.windows) {
-                    if (window.isKeyWindow) {
-                        keyWindow = window;
-                        break;
-                    }
+    NSSet<UIScene *> *connectedScenes = [UIApplication sharedApplication].connectedScenes;
+    for (UIScene *scene in connectedScenes) {
+        if ([scene isKindOfClass:[UIWindowScene class]]) {
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            for (UIWindow *window in windowScene.windows) {
+                if (window.isKeyWindow) {
+                    keyWindow = window;
+                    break;
                 }
-                if (keyWindow) break;
             }
+            if (keyWindow) break;
         }
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Closes: https://github.com/ExodusMovement/exodus-mobile/issues/27007

Mobile side PR: https://github.com/ExodusMovement/exodus-mobile/pull/29077


To test this on mobile,

Copy the files from this branch and paste them into the appropriate locations inside `src/node_modules/@exodus/react-native-screenshot-detector` in the mobile repo.

Once that’s done, switch to the mobile branch of [this PR](https://github.com/ExodusMovement/exodus-mobile/pull/29077), connect a real iOS device, and start testing.



https://github.com/user-attachments/assets/ca75a905-bbca-4625-876b-af1c3149c3e8


https://github.com/user-attachments/assets/3710d2e8-8e19-4b07-96f1-58eb831c23ff


https://github.com/user-attachments/assets/872e906a-8558-49da-b3f9-1c6f752bcf39
