### PR TITLE
fix: prevent NPE when activity is null in screenshot detector on Android

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
+++ b/android/src/main/java/com/reactlibrary/RNScreenshotDetectorModule.java
@@ -1,6 +1,7 @@
 
 package com.reactlibrary;
 
+import android.app.Activity;
 import android.view.Window;
 import android.view.WindowManager;
 
@@ -25,25 +26,38 @@ public class RNScreenshotDetectorModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void disableScreenshots() {
-    getCurrentActivity().runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
-      }
-    });
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity != null) {
+      currentActivity.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          Window window = getWindow();
+          if (window != null) {
+            window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
+          }
+        }
+      });
+    }
   }
 
   @ReactMethod
   public void enableScreenshots() {
-    getCurrentActivity().runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
-      }
-    });
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity != null) {
+      currentActivity.runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          Window window = getWindow();
+          if (window != null) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+          }
+        }
+      });
+    }
   }
 
   private Window getWindow() {
-    return getCurrentActivity().getWindow();
+    Activity currentActivity = getCurrentActivity();
+    return currentActivity != null ? currentActivity.getWindow() : null;
   }
 }


### PR DESCRIPTION
Closes: https://github.com/ExodusMovement/exodus-mobile/issues/29676

**Error Details:**
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.app.Activity.runOnUiThread(java.lang.Runnable)' on a null object reference
at com.reactlibrary.RNScreenshotDetectorModule.enableScreenshots (RNScreenshotDetectorModule.java:38)
```

The methods `disableScreenshots()` and `enableScreenshots()` were calling `getCurrentActivity().runOnUiThread()` without checking if the current activity is null. This can happen when:
- The app is in the background
- The activity is being destroyed
- The app is transitioning between activities

The fix ensures that calling `Screenshots.disableScreenshots()` and `Screenshots.enableScreenshots()` from JS will never crash, regardless of the app's current state.