### PR TITLE
fix: restore layer hierarchy by storing original references

### DIFF
--- a/ios/RNScreenshotDetector/RNScreenshotDetector.m
+++ b/ios/RNScreenshotDetector/RNScreenshotDetector.m
@@ -13,6 +13,8 @@
     id screenshotObserver;
     id screenRecordingObserver;
     BOOL isProtectionEnabled;
+    UIWindow *originalKeyWindow;      
+    CALayer *originalSuperlayer;      
 }
 
 RCT_EXPORT_MODULE();
@@ -91,7 +93,6 @@ RCT_EXPORT_METHOD(isScreenRecording:(RCTPromiseResolveBlock)resolve
     resolve(@(isRecording));
 }
 
-// Clear and explicit method names
 RCT_EXPORT_METHOD(subscribeToScreenshotAndScreenRecording) {
     [self startObserving];
 }
@@ -102,32 +103,58 @@ RCT_EXPORT_METHOD(unsubscribeFromScreenshotAndScreenRecording) {
 
 // Screenshot Prevention using Secure Text Field
 - (void)enableTrueScreenshotPrevention {
-    if (self.secureTextField == nil) {
-        self.secureTextField = [[UITextField alloc] init];
-        self.secureTextField.userInteractionEnabled = NO;
-        self.secureTextField.secureTextEntry = YES;
+    @try {
+        if (self.secureTextField == nil) {
+            self.secureTextField = [[UITextField alloc] init];
+            self.secureTextField.userInteractionEnabled = NO;
+            self.secureTextField.secureTextEntry = YES;
+        }
         
         UIWindow *keyWindow = [self getKeyWindow];
         if (keyWindow != nil) {
+            originalKeyWindow = keyWindow;
+            originalSuperlayer = keyWindow.layer.superlayer;
+            
             [keyWindow makeKeyAndVisible];
             
-            // Make the app window a sublayer of the secure text field
-            [keyWindow.layer.superlayer addSublayer:self.secureTextField.layer];
-            
-            // Add the window layer as a sublayer of the secure text field's first sublayer
-            NSArray *sublayers = self.secureTextField.layer.sublayers;
-            if (sublayers.count > 0) {
-                [sublayers.firstObject addSublayer:keyWindow.layer];
-            }
-        }
-    } else {
-        self.secureTextField.secureTextEntry = YES;
+            if (originalSuperlayer != nil) {
+                [originalSuperlayer addSublayer:self.secureTextField.layer];
+                
+                [keyWindow.layer removeFromSuperlayer];
+                
+                NSArray *sublayers = self.secureTextField.layer.sublayers;
+                if (sublayers.count > 0) {
+                    [sublayers.firstObject addSublayer:keyWindow.layer];
+                } else {
+                    [self.secureTextField.layer addSublayer:keyWindow.layer];
+                }
+            }   
+        } 
+    } @catch (NSException *exception) {
+        NSLog(@"[RNScreenshotDetector] Error in enableTrueScreenshotPrevention: %@", exception);
     }
 }
 
 - (void)disableTrueScreenshotPrevention {
-    if (self.secureTextField != nil) {
-        self.secureTextField.secureTextEntry = NO;
+    @try {
+        if (self.secureTextField != nil) {
+            self.secureTextField.secureTextEntry = NO;
+            
+            if (originalKeyWindow != nil && originalSuperlayer != nil) {
+                [originalKeyWindow.layer removeFromSuperlayer];
+                [originalSuperlayer addSublayer:originalKeyWindow.layer];
+                
+                [self.secureTextField.layer removeFromSuperlayer];
+            }
+            
+            originalKeyWindow = nil;
+            originalSuperlayer = nil;
+            
+            [self.secureTextField removeFromSuperview];
+            self.secureTextField = nil;
+        }
+    } @catch (NSException *exception) {
+        NSLog(@"[RNScreenshotDetector] Error in disableTrueScreenshotPrevention: %@", exception);
     }
 }
 


### PR DESCRIPTION
Closes: https://github.com/ExodusMovement/exodus-mobile/issues/29660
Closes: https://github.com/ExodusMovement/exodus-mobile/issues/29666


The issue stemmed from the iOS native screenshot prevention implementation in `RNScreenshotDetector.m`. The `enableTrueScreenshotPrevention` method creates a secure `UITextField` and manipulates the window layer hierarchy by:
   - Adding the secure text field layer to the window's superlayer
   - Moving the main window layer as a sublayer of the secure text field

But during app restart (triggered by language change), the layer structure wasn't properly restored to its original state, leaving the secure layer active and causing the black screen

The original code didn't maintain references to the original window and superlayer, making proper restoration impossible.

So I've added logic to restore layer hierarchy by storing original references.



- ✅ Passcode functionality works normally
- ✅ Screenshot prevention active when passcode screen is shown
- ✅ Language change triggers normal app restart without black screen
- ✅ Layer structure properly restored after screenshot protection is disabled




https://github.com/user-attachments/assets/6c65e707-6c57-44e1-8d97-9967911adcbf

