### PR TITLE
fix(android): replace jcenter() with mavenCentral() for Gradle 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.5",
+  "version": "1.2.5-exodus.0",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "gcarling",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ExodusMovement/react-native-screenshot-detector"
+    "url": "https://github.com/ExodusForks/react-native-screenshot-detector"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Minimal patch on top of published 1.2.5 to swap `jcenter()` -> `mavenCentral()` for Gradle 9 / RN 0.85. Introduces `-exodus.N` suffix; new version: 1.2.5-exodus.0.