### PR TITLE
fix(android): guard undefined native module to prevent TypeError

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -2,12 +2,27 @@
 
 import { NativeModules } from 'react-native'
 
+const { RNScreenshotDetector } = NativeModules
+
 const unsubscribe = () => {}
 const subscribe = () => unsubscribe
 
+const disableScreenshots = () => {
+  if (RNScreenshotDetector && RNScreenshotDetector.disableScreenshots) {
+    RNScreenshotDetector.disableScreenshots()
+  }
+}
+
+const enableScreenshots = () => {
+  if (RNScreenshotDetector && RNScreenshotDetector.enableScreenshots) {
+    RNScreenshotDetector.enableScreenshots()
+  }
+}
+
 const Detector = {
-  ...NativeModules.RNScreenshotDetector,
   subscribe,
+  disableScreenshots,
+  enableScreenshots,
 }
 
 export default Detector

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary

* `index.android.js` previously spread `NativeModules.RNScreenshotDetector` and re-exported `disableScreenshots` / `enableScreenshots`.
* On Android 36, the native module can be `undefined`, which means those two methods are not added to the exported object.
* As a result, when consumers call `Detector.disableScreenshots()`, it throws `TypeError: Value is not a function` (for example in `refCountedDisableScreenshots`).
* Replaced the implementation with a thin wrapper that checks both the native module and method existence before calling them. If the native module is unavailable, the functions safely no-op.
* Bumped the package version to `1.2.6`.

## Context

* exodus-mobile crash report: ExodusMovement/exodus-mobile#38080
* Consumer-side hotfix: ExodusMovement/exodus-mobile#38081 (already prepared)
* Applying the fix at the package level also protects `recovery.js` and any future callers from the same issue.

## Test Plan

* [ ] On Android 36 devices/emulators, calling `disableScreenshots()` / `enableScreenshots()` does not crash and safely no-ops.
* [ ] On Android 35 and below, existing behavior (screenshot blocking) still works as expected.
* [ ] No impact on iOS behavior (changes are limited to `index.android.js`).
* [ ] After publishing `1.2.6` to npm, update the dependency in exodus-mobile and run a smoke test.
