### PR TITLE
fix(android): fail-closed when native module is missing

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -1,6 +1,9 @@
-// TODO: check out https://github.com/abangfadli/shotwatch
-
 import { NativeModules } from 'react-native'
+
+const LINKING_ERROR =
+  `@exodus/react-native-screenshot-detector: native module 'RNScreenshotDetector' is not linked. ` +
+  `Rebuild the Android app from source so the native module is bundled. ` +
+  `Refusing to no-op for security-critical screenshot protection.`
 
 const { RNScreenshotDetector } = NativeModules
 
@@ -8,15 +11,17 @@ const unsubscribe = () => {}
 const subscribe = () => unsubscribe
 
 const disableScreenshots = () => {
-  if (RNScreenshotDetector && RNScreenshotDetector.disableScreenshots) {
-    RNScreenshotDetector.disableScreenshots()
+  if (!RNScreenshotDetector || !RNScreenshotDetector.disableScreenshots) {
+    throw new Error(LINKING_ERROR)
   }
+  RNScreenshotDetector.disableScreenshots()
 }
 
 const enableScreenshots = () => {
-  if (RNScreenshotDetector && RNScreenshotDetector.enableScreenshots) {
-    RNScreenshotDetector.enableScreenshots()
+  if (!RNScreenshotDetector || !RNScreenshotDetector.enableScreenshots) {
+    throw new Error(LINKING_ERROR)
   }
+  RNScreenshotDetector.enableScreenshots()
 }
 
 const Detector = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/react-native-screenshot-detector",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "detect when the user takes a screenshot",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## Summary
- Replace 1.2.6's silent fail-open in `disableScreenshots`/`enableScreenshots` with an explicit `throw` when `NativeModules.RNScreenshotDetector` is absent.
- Bumps to **1.2.7**.

## Why
Audit on consumer PR ExodusMovement/exodus-mobile#38081 BLOCKED 1.2.6 with two findings (`error-path` and `consumer`):
- 1.2.6 silently no-ops when the native bridge is missing → `FLAG_SECURE` never applied → seed-phrase / private-key screens render screen-capturable with no signal.
- Suggested fix: "preserve fail-loud behavior by throwing an explicit error when RNScreenshotDetector or its method is missing."

This PR implements exactly that contract for Android and is the **strict minimum** to unblock that audit.

## Scope
- Touches `index.android.js` and `package.json` only.
- iOS file unchanged (no audit findings, no production crashes).
- Gradle / AndroidManifest unchanged (modernization is independent hygiene; will be a separate PR).

## Test plan
- [ ] `Detector.disableScreenshots()` / `enableScreenshots()` forward to native methods when bridge is present (smoke on a normal Android release build).
- [ ] When `NativeModules.RNScreenshotDetector` is absent, both methods throw `LINKING_ERROR` instead of silent no-op.
- [ ] iOS path is byte-for-byte unchanged from 1.2.6.

Refs: ExodusMovement/exodus-mobile#38080, ExodusMovement/exodus-mobile#38081